### PR TITLE
Fix password length validation text

### DIFF
--- a/backendv4/src/main/java/com/hicode/backend/dto/RegisterRequest.java
+++ b/backendv4/src/main/java/com/hicode/backend/dto/RegisterRequest.java
@@ -19,7 +19,7 @@ public class RegisterRequest {
     private String email;
 
     @NotBlank(message = "Password is required")
-    @Size(min = 6, max = 100, message = "Password need to longer than 6")
+    @Size(min = 6, max = 100, message = "Password needs to be longer than 6 characters")
     private String password;
 
     @NotBlank(message = "Phone number is required")


### PR DESCRIPTION
## Summary
- reword password length validation message in RegisterRequest

## Testing
- `mvn test` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_684c0f00bef08326bd902e85c3fe2d9e