### PR TITLE
Fix package for BloodCompatibilityDetailResponse

### DIFF
--- a/backendv4/src/main/java/com/hicode/backend/controller/BloodCompatibilityController.java
+++ b/backendv4/src/main/java/com/hicode/backend/controller/BloodCompatibilityController.java
@@ -1,6 +1,6 @@
 package com.hicode.backend.controller;
 
-import com.hicode.backend.dto.BloodCompatibilityDetailResponse;
+import com.hicode.backend.dto.admin.BloodCompatibilityDetailResponse;
 import com.hicode.backend.dto.admin.CreateBloodCompatibilityRequest;
 import com.hicode.backend.dto.admin.UpdateBloodCompatibilityRequest;
 import com.hicode.backend.service.BloodManagementService;

--- a/backendv4/src/main/java/com/hicode/backend/dto/admin/BloodCompatibilityDetailResponse.java
+++ b/backendv4/src/main/java/com/hicode/backend/dto/admin/BloodCompatibilityDetailResponse.java
@@ -1,4 +1,4 @@
-package com.hicode.backend.dto;
+package com.hicode.backend.dto.admin;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/backendv4/src/main/java/com/hicode/backend/service/BloodManagementService.java
+++ b/backendv4/src/main/java/com/hicode/backend/service/BloodManagementService.java
@@ -1,7 +1,7 @@
 package com.hicode.backend.service;
 
 import com.hicode.backend.dto.*;
-import com.hicode.backend.dto.BloodCompatibilityDetailResponse;
+import com.hicode.backend.dto.admin.BloodCompatibilityDetailResponse;
 import com.hicode.backend.dto.admin.CreateBloodCompatibilityRequest;
 import com.hicode.backend.dto.admin.CreateBloodTypeRequest;
 import com.hicode.backend.dto.admin.UpdateBloodCompatibilityRequest;

--- a/backendv4/src/test/java/com/hicode/backend/controller/BloodCompatibilityControllerTest.java
+++ b/backendv4/src/test/java/com/hicode/backend/controller/BloodCompatibilityControllerTest.java
@@ -1,6 +1,6 @@
 package com.hicode.backend.controller;
 
-import com.hicode.backend.dto.BloodCompatibilityDetailResponse;
+import com.hicode.backend.dto.admin.BloodCompatibilityDetailResponse;
 import com.hicode.backend.service.BloodManagementService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
## Summary
- move `BloodCompatibilityDetailResponse` into the `admin` package
- update imports for new package usage in service, controller, and tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_684c0f11ba38832690cb9ace9337d9a8